### PR TITLE
Add subscription plans page for Iaphiel

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,10 @@
     <div class="overlay">
       <h1>CelestIA</h1>
       <p>Entrenamos modelos de Inteligencia Artificial para darte el mejor consejo.</p>
-      <a href="#documentos" class="btn">Ver documentos</a>
+      <div class="hero-actions">
+        <a href="#documentos" class="btn">Ver documentos</a>
+        <a href="planes.html" class="btn btn-secondary">Planes de suscripción</a>
+      </div>
     </div>
   </header>
 

--- a/planes.html
+++ b/planes.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Planes de Suscripción - CelestIA</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="internal-header">
+    <a href="index.html">CelestIA</a>
+    <nav>
+      <a href="index.html">Inicio</a>
+      <a href="#planes">Planes</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="section intro">
+      <h1>Planes de suscripción de Iaphiel</h1>
+      <p>
+        Descubre cómo <strong>Iaphiel</strong>, el chatbot angelical de CelestIA, te acompaña con consejos inspiradores y
+        reflexiones sobre las Sagradas Escrituras a través de WhatsApp. Cada plan incluye interacciones ilimitadas y
+        disponibilidad 24/7 para que recibas guía y compañía espiritual cuando más la necesites.
+      </p>
+    </section>
+
+    <section class="section" id="planes">
+      <h2>Elige la guía celestial que necesitas</h2>
+      <div class="plans-grid">
+        <article class="plan-card">
+          <h3>Plan Mensual</h3>
+          <p class="duration">1 mes</p>
+          <p class="price">$50.000 COP</p>
+          <ul class="plan-features">
+            <li>Interacciones ilimitadas con Iaphiel por WhatsApp.</li>
+            <li>Disponibilidad continua las 24 horas.</li>
+            <li>Recomendaciones espirituales y recordatorios personalizados.</li>
+          </ul>
+          <a class="btn" href="https://wa.me/" target="_blank" rel="noopener">Comenzar ahora</a>
+        </article>
+
+        <article class="plan-card highlight">
+          <h3>Plan Semestral</h3>
+          <p class="duration">6 meses</p>
+          <p class="price">$252.000 COP</p>
+          <ul class="plan-features">
+            <li>Acompañamiento angelical constante con enfoque a mediano plazo.</li>
+            <li>Interacciones ilimitadas y disponibilidad permanente.</li>
+            <li>Mensajes temáticos para las temporadas litúrgicas y fechas especiales.</li>
+          </ul>
+          <a class="btn btn-secondary" href="https://wa.me/" target="_blank" rel="noopener">Hablar con nosotros</a>
+        </article>
+
+        <article class="plan-card">
+          <h3>Plan Anual</h3>
+          <p class="duration">12 meses</p>
+          <p class="price">$420.000 COP</p>
+          <ul class="plan-features">
+            <li>Un año entero de guía personalizada de Iaphiel.</li>
+            <li>Acceso prioritario a novedades y contenidos especiales.</li>
+            <li>Seguimiento mensual de tus metas espirituales.</li>
+          </ul>
+          <a class="btn" href="https://wa.me/" target="_blank" rel="noopener">Solicitar plan</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="guarantee">
+        <h2>Tu conexión con Iaphiel siempre disponible</h2>
+        <p>
+          Independientemente del plan que elijas, mantendrás acceso ilimitado a conversaciones con Iaphiel en cualquier
+          momento del día. Nuestro compromiso es brindarte una experiencia cercana y respetuosa, guiada por valores
+          espirituales y respaldada por la tecnología de CelestIA.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>© 2025 CelestIA · Todos los derechos reservados</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -22,6 +22,20 @@ body {
   border-radius: 10px;
 }
 
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+@media (min-width: 600px) {
+  .hero-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
 h1 {
   font-size: 3rem;
   margin-bottom: 0.5rem;
@@ -69,9 +83,128 @@ a:hover {
   background: #00337a;
 }
 
+.btn-secondary {
+  background: transparent;
+  border: 2px solid #ffffff;
+}
+
+.btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
 footer {
   background: #111;
   color: white;
   text-align: center;
   padding: 1rem;
+}
+
+.internal-header {
+  background: #004aad;
+  color: white;
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.internal-header a {
+  color: white;
+  font-weight: bold;
+}
+
+.internal-header nav a {
+  margin-left: 1rem;
+  font-weight: normal;
+}
+
+.intro {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.plans-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.plan-card {
+  background: #f7f9fc;
+  border-radius: 12px;
+  padding: 2rem 1.5rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 74, 173, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.plan-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 35px rgba(0, 0, 0, 0.12);
+}
+
+.plan-card.highlight {
+  background: #004aad;
+  color: white;
+}
+
+.plan-card h3 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.plan-card .price {
+  font-size: 2rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.plan-card .duration {
+  font-weight: bold;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+  color: #004aad;
+}
+
+.plan-card.highlight .duration,
+.plan-card.highlight a,
+.plan-card.highlight .price {
+  color: white;
+}
+
+.plan-features {
+  margin: 1.5rem 0;
+  padding: 0;
+}
+
+.plan-features li {
+  margin: 0.5rem 0;
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+.plan-features li::before {
+  content: "✶";
+  position: absolute;
+  left: 0;
+  color: #004aad;
+}
+
+.plan-card.highlight .plan-features li::before {
+  color: #ffffff;
+}
+
+.plan-card .btn {
+  margin-top: 1rem;
+}
+
+.guarantee {
+  max-width: 700px;
+  margin: 0 auto;
+  background: rgba(0, 74, 173, 0.08);
+  padding: 1.5rem;
+  border-radius: 10px;
+  border-left: 4px solid #004aad;
 }


### PR DESCRIPTION
## Summary
- add a call-to-action in the landing hero that links to the new subscription offerings
- create a dedicated plans page detailing Iaphiel's monthly, semestral, and annual options with included benefits
- extend the shared stylesheet with layout and presentation styles for the pricing grid and supporting sections

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da95893300832b96d41d7f50b8930f