### PR TITLE
Integrate subscription plans into main landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,28 +14,92 @@
       <p>Entrenamos modelos de Inteligencia Artificial para darte el mejor consejo.</p>
       <div class="hero-actions">
         <a href="#documentos" class="btn">Ver documentos</a>
-        <a href="planes.html" class="btn btn-secondary">Planes de suscripción</a>
+        <a href="#planes" class="btn btn-secondary">Planes de suscripción</a>
       </div>
     </div>
   </header>
 
-  <!-- Sección Misión -->
-  <section class="section">
-    <h2>Nuestra misión</h2>
-    <p>
-      En CelestIA creemos que la inteligencia artificial puede ayudar a las personas a tomar
-      mejores decisiones en su vida personal y profesional. Entrenamos modelos de IA de última
-      generación con un enfoque humano, transparente y responsable.
-    </p>
-  </section>
+  <main>
+    <!-- Sección Misión -->
+    <section class="section">
+      <h2>Nuestra misión</h2>
+      <p>
+        En CelestIA creemos que la inteligencia artificial puede ayudar a las personas a tomar
+        mejores decisiones en su vida personal y profesional. Entrenamos modelos de IA de última
+        generación con un enfoque humano, transparente y responsable.
+      </p>
+    </section>
 
-  <!-- Sección Documentos -->
-  <section class="section" id="documentos">
-    <h2>Documentos Institucionales</h2>
-    <ul>
-      <li><a href="politica-datos.pdf" target="_blank">📄 Política de Protección de Datos Personales</a></li>
-    </ul>
-  </section>
+    <!-- Sección Planes -->
+    <section class="section intro">
+      <h2>Planes de suscripción de Iaphiel</h2>
+      <p>
+        Descubre cómo <strong>Iaphiel</strong>, el chatbot angelical de CelestIA, te acompaña con consejos inspiradores y
+        reflexiones sobre las Sagradas Escrituras a través de WhatsApp. Cada plan incluye interacciones ilimitadas y
+        disponibilidad 24/7 para que recibas guía y compañía espiritual cuando más la necesites.
+      </p>
+    </section>
+
+    <section class="section" id="planes">
+      <h2>Elige la guía celestial que necesitas</h2>
+      <div class="plans-grid">
+        <article class="plan-card">
+          <h3>Plan Mensual</h3>
+          <p class="duration">1 mes</p>
+          <p class="price">$50.000 COP</p>
+          <ul class="plan-features">
+            <li>Interacciones ilimitadas con Iaphiel por WhatsApp.</li>
+            <li>Disponibilidad continua las 24 horas.</li>
+            <li>Recomendaciones espirituales y recordatorios personalizados.</li>
+          </ul>
+          <a class="btn" href="https://wa.me/" target="_blank" rel="noopener">Comenzar ahora</a>
+        </article>
+
+        <article class="plan-card highlight">
+          <h3>Plan Semestral</h3>
+          <p class="duration">6 meses</p>
+          <p class="price">$252.000 COP</p>
+          <ul class="plan-features">
+            <li>Acompañamiento angelical constante con enfoque a mediano plazo.</li>
+            <li>Interacciones ilimitadas y disponibilidad permanente.</li>
+            <li>Mensajes temáticos para las temporadas litúrgicas y fechas especiales.</li>
+          </ul>
+          <a class="btn btn-secondary" href="https://wa.me/" target="_blank" rel="noopener">Hablar con nosotros</a>
+        </article>
+
+        <article class="plan-card">
+          <h3>Plan Anual</h3>
+          <p class="duration">12 meses</p>
+          <p class="price">$420.000 COP</p>
+          <ul class="plan-features">
+            <li>Un año entero de guía personalizada de Iaphiel.</li>
+            <li>Acceso prioritario a novedades y contenidos especiales.</li>
+            <li>Seguimiento mensual de tus metas espirituales.</li>
+          </ul>
+          <a class="btn" href="https://wa.me/" target="_blank" rel="noopener">Solicitar plan</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="guarantee">
+        <h2>Tu conexión con Iaphiel siempre disponible</h2>
+        <p>
+          Independientemente del plan que elijas, mantendrás acceso ilimitado a conversaciones con Iaphiel en cualquier
+          momento del día. Nuestro compromiso es brindarte una experiencia cercana y respetuosa, guiada por valores
+          espirituales y respaldada por la tecnología de CelestIA.
+        </p>
+      </div>
+    </section>
+
+    <!-- Sección Documentos -->
+    <section class="section" id="documentos">
+      <h2>Documentos Institucionales</h2>
+      <ul>
+        <li><a href="politica-datos.pdf" target="_blank">📄 Política de Protección de Datos Personales</a></li>
+      </ul>
+    </section>
+  </main>
 
   <!-- Footer -->
   <footer>


### PR DESCRIPTION
## Summary
- embed the subscription plan introduction, plan cards, and guarantee sections directly in `index.html` so all content lives on a single page
- update the hero call-to-action to scroll to the in-page plans section while keeping institutional documents accessible

## Testing
- no tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68da9a4b7824832bbaa796bb845fea0e